### PR TITLE
[Fix] Missing Wiki

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -8,6 +8,7 @@
 - [Guides]()
     - [Introduction](./guides/introduction.md)
     - [Beginning](./guides/beginning.md)
+        - [Bot Status](./guides/botStatus.md)
         - [Commands Anatomy](./guides/commandsAnatomy.md)
         - [Gateway Intents](./guides/gatewayIntents.md)
         - [Variables](./guides/variables.md)


### PR DESCRIPTION
Fixed `botStatus.md` wiki which wasn't included in the `SUMMARY.md`