### PR TITLE
Update variables.css, for Terminal theme breaking into other themes, this update should fix that.

### DIFF
--- a/src/theme/css/variables.css
+++ b/src/theme/css/variables.css
@@ -57,9 +57,7 @@
     color: #eadfff;
     background-color: #302638;
 }
-.ios {
-    text-shadow: 0 0 10px #42316a;
-}
+
 .ios {
     --bg: #221c2a;
     --fg: #eadfff;
@@ -334,19 +332,11 @@
 
     --chapter-hover-bg: var(--theme-hover);
 
-    font: 65% Inconsolata, monospace;
 }
 
-.terminal a:not(.header),
-h1:not(.header),
-i:not(.header),
-li:not(.header) {
-    text-shadow: 0 0 5px #C8C8C8;
-}
-
-.terminal h3:not(.header),
-p:not(.header) {
-    text-shadow: 0 0 5px #149414;
+.terminal {
+    font-family: Inconsolata, monospace;
+    text-shadow: 0 0 10px #149414;
 }
 /* Terminal */
 /* Community Themes */


### PR DESCRIPTION
My Terminal themes shadow would break into the other themes.

Before:
![image](https://user-images.githubusercontent.com/113247745/198881046-761a23cf-039a-4c33-be28-c88eec54d1f3.png)
![image](https://user-images.githubusercontent.com/113247745/198881054-deaf5b6d-e609-453e-8314-02d363321975.png)
After:
![image](https://user-images.githubusercontent.com/113247745/198881095-afd5b98f-d19a-4f2c-a7a2-8256da059f0a.png)

- Fodex (scawy)#4150