### PR TITLE
Wiki Refactoring #1

### DIFF
--- a/src/bdscript/addButton.md
+++ b/src/bdscript/addButton.md
@@ -3,35 +3,43 @@ Adds button to the response.
 
 ## Syntax
 ```
-$addButton[new row?;interaction ID/url;label;style;(disable?;emoji;message ID)]
+$addButton[new row;interaction ID/url;label;style;(disable?;emoji;message ID)]
 ```
 
 ### Parameters
-- `new row?` `(Type: Bool || Flag: Required)`: If set to `yes` the button will appear in a new row. If it's set to `no` the button will appear in the same row as a previous button.
 
-    > A message can have a maximum of 25 buttons (5 rows of 5 buttons).
+| Argument            | Description                                                                                                                             | Type        | Flag       |
+|---------------------|-----------------------------------------------------------------------------------------------------------------------------------------|-------------|------------|
+| new row             | If set to `yes`, the button will appear in a new row. If set to `no`, the button will appear in the same row as a previous button.       | Bool        | Required   |
+| interaction ID/url  | Depending on the button type, set it to the interaction ID to be used in the `$onInteraction[ID]` callback, or set it to a URL if it's a link button. | String, URL | Required   |
+| label               | The text value visible on the button.                                                                                                   | String      | Emptiable  |
+| style               | Used to specify the button's background color. If the button has a link/URL, it must be set to `link`. Refer to the [button style section](#button-style) for more details. | Enum        | Required   |
+| disable?            | If set to `yes`, the button cannot be pressed. Defaults to `no`.                                                                        | Bool        | Vacantable |
+| emoji               | Adds an emoji inside the button. Emojis can be pasted as *unicode* or in the format `<:emoji name:emoji ID>`.                           | Emoji       | Vacantable |
+| message ID          | Adds a button to the provided message ID. Note that the author of the provided message ID must be the bot.                              | Snowflake   | Vacantable |
 
-- `interaction ID/url` `(Type: String, URL || Flag: Required)`: Depending on the button type, you either set it to `interaction ID` which is then used in `$onInteraction[ID]` callback or `URL` if it's a link button.
-- `label` `(Type: String || Flag: Emptiable)`: The text value visible on the button.
-- `style` `(Type: Enum || Flag: Required)`: It's used to specify the button's background color. If the button has a link/url you **have to** set the value to `link`. Check [this section](#button-style) for more details.
-- `disable?` `(Type: Bool || Flag: Vacantable)`: If set to `yes` the button can't be pressed. Defaults as `no`.
-- `emoji` `(Type: Emoji || Flag: Vacantable)`: Adds an emoji inside the button. Emojis have to be either pasted as *unicode* or be in the following format `<:emoji name:emoji ID>`.
-- `message ID` `(Type: Snowflake || Flag: Vacantable)`: Adds a button to the provided message ID. It's important to note that provided message ID author **has to** be the bot.
 
-> Interactive buttons can't have duplicated `ID`'s in the same message. So for example, you can't have two buttons with the ID set to `test`.
+### Note :
+1- A message can have a maximum of 25 buttons (5 rows of 5 buttons).
 
-> If `url` is used in `interaction ID/url` argument, it **has to** start with `http://` or `https://`
+2- Interactive buttons can't have duplicated `ID`'s in the same message. So for example, you can't have two buttons with the ID set to `test`.
+
+3- If `url` is used in `interaction ID/url` argument, it **has to** start with `http://` or `https://`
 
 ## Button Style
 Buttons can have different styles _(background colors)_.
 Here, are all possible values for `style` function argument.
-- `primary`: Blue button
-- `secondary`: Gray button
-- `success`: Green button
-- `danger`: Red button
-- `link`: Redirect button
 
-> If `link` style is used, the button **won't send** any interactions!
+| Style      | Color    |
+|------------|----------|
+| primary    | Blue     |
+| secondary  | Gray     |
+| success    | Green    |
+| danger     | Red      |
+| link       | Redirect |
+
+
+### Note :  If `link` style is used, the button **won't send** any interactions!
 
 ## Example
 ```

--- a/src/bdscript/addCmdReactions.md
+++ b/src/bdscript/addCmdReactions.md
@@ -7,8 +7,13 @@ $addCmdReactions[emojis;...]
 ```
 
 ### Parameters
-- `emojis` `(Type: Emoji || Flag: Required)`: The emoji(s) the bot reacts with. Separate emojis using `;`.
 
+| Argument | Description                                     | Type  | Flag     |
+|----------|-------------------------------------------------|-------|----------|
+| emojis   | The emoji(s) the bot reacts with. Separate emojis using `;`. | Emoji | Required |
+
+
+### Note :
 > You can use Unicode emojis and emoji IDs, but not emoji names. For **emoji IDs**, the bot must be present in the server that the emoji originates from. 
 > 
 > List of unicode emojis: [😋 Get Emoji](https://getemoji.com)

--- a/src/bdscript/addEmoji.md
+++ b/src/bdscript/addEmoji.md
@@ -7,9 +7,13 @@ $addEmoji[name;image URL;return emoji?]
 ```
 
 ### Parameters
-- `name` `(Type: String || Flag: Required)`: The name of the new emoji.
-- `image URL` `(Type: URL || Flag: Required)`: The image of the new emoji. The link needs to be a valid image URL.
-- `return emoji?` `(Type: Bool || Flag: Required)`: Whether to show the emoji in the bot's message or not. (`yes`/`no`)
+
+| Argument    | Description                                   | Type | Flag     |
+|-------------|-----------------------------------------------|------|----------|
+| name        | The name of the new emoji.                     | String | Required |
+| image URL   | The image of the new emoji.                    | URL    | Required |
+| return emoji? | Whether to show the emoji in the bot's message or not. (`yes`/`no`) | Bool | Required |
+
 
 ## Example
 ```

--- a/src/bdscript/addField.md
+++ b/src/bdscript/addField.md
@@ -5,15 +5,21 @@ Adds a field to an embed.
 ```
 $addField[name;value;(inline?;index)]
 ```
-> You can create up to 25 fields per embed.
 
 ### Parameters
-- `name` `(Type: String || Flag: Required)`: The name of the field. It cannot exceed more than 256 characters.
-- `value` `(Type: String || Flag: Required)`: The value of the field. It cannot exceed more than 1024 characters.
-- `inline?` `(Type: Bool || Flag: Optional)`: If `yes`, fields will appear in the same line. However, if you have more than 3 fields (or the fields are just too long) with inline enabled, the bot will return rows with 3 fields (2 if there is a thumbnail) in each row. It is set to `no` by default.
-- `index` `(Type: Integer || Flag: Optional)`: Adds field to specified embed index number. [(learn more)](../resources/embedIndexes.md)
 
-> Inline fields may not appear inline on some mobile devices.
+| Argument | Description                                                                                                            | Type    | Flag     |
+|----------|------------------------------------------------------------------------------------------------------------------------|---------|----------|
+| name     | The name of the field. It cannot exceed more than 256 characters.                                                     | String  | Required |
+| value    | The value of the field. It cannot exceed more than 1024 characters.                                                    | String  | Required |
+| inline?  | If `yes`, fields will appear in the same line. However, if you have more than 3 fields (or the fields are just too long) with inline enabled, the bot will return rows with 3 fields (2 if there is a thumbnail) in each row. It is set to `no` by default. | Bool    | Optional |
+| index    | Adds the field to the specified embed index number. [Learn more](../resources/embedIndexes.md).                         | Integer | Optional |
+
+
+### Note :
+1- You can create up to 25 fields per embed.
+
+2- Inline fields may not appear inline on some mobile devices.
 
 ## Examples
 

--- a/src/bdscript/addReactions.md
+++ b/src/bdscript/addReactions.md
@@ -7,8 +7,13 @@ $addReactions[emojis;...]
 ```
 
 ### Parameters
-- `emojis` `(Type: Emoji || Flag: Required)`: The emoji(s) the bot reacts with. Separate emojis using `;`.
 
+| Argument | Description                                      | Type  | Flag     |
+|----------|--------------------------------------------------|-------|----------|
+| emojis   | The emoji(s) the bot reacts with. Separate emojis using `;`. | Emoji | Required |
+
+
+### Note
 > You can use Unicode emojis and emoji IDs, but not emoji names. For **emoji IDs**, the bot must be present in the server that the emoji originates from. 
 > 
 > List of unicode emojis: [😋 Get Emoji](https://getemoji.com)

--- a/src/bdscript/addSelectMenuOption.md
+++ b/src/bdscript/addSelectMenuOption.md
@@ -6,13 +6,17 @@ Adds select menu option to a select menu.
 $addSelectMenuOption[menu option ID;label;value;description;(default?;emoji;message ID)]
 ```
 ### Parameters
-- `menu option ID` `(Type: String || Flag: Required)`: The ID used in `$newSelectMenu[]`.
-- `label` `(Type: String || Flag: Required)`: The name of the option.
-- `value` `(Type: String || Flag: Required)`: It's the data that gets passed to `$onInteraction[]` callback. **The value has to be unique in the select menu!**
-- `description` `(Type: String || Flag: Emptiable)`: A text which shows up under the `label`.
-- `default?` `(Type: Bool || Flag: Vacantable)`: Should the option be selected by default. (yes/no) **There can be only one default option!**
-- `emoji` `(Type: Emoji || Flag: Vacantable)`: It shows up next to the `label`.
-- `message ID` `(Type: String || Flag: Vacantable)`: ID of a message that should have select menu added to it. By default it's the bot's response.
+
+| Argument       | Description                                                                 | Type   | Flag       |
+|----------------|-----------------------------------------------------------------------------|--------|------------|
+| menu option ID | The ID used in `$newSelectMenu[]`.                                          | String | Required   |
+| label          | The name of the option.                                                     | String | Required   |
+| value          | It's the data that gets passed to `$onInteraction[]` callback.               | String | Required   |
+| description    | A text which shows up under the `label`.                                     | String | Emptiable  |
+| default?       | Should the option be selected by default. (yes/no) **There can be only one default option!** | Bool   | Vacantable |
+| emoji          | It shows up next to the `label`.                                             | Emoji  | Vacantable |
+| message ID     | ID of a message that should have select menu added to it. By default it's the bot's response. | String | Vacantable |
+
 
 ## Example
 ```

--- a/src/bdscript/addTextInput.md
+++ b/src/bdscript/addTextInput.md
@@ -8,14 +8,19 @@ $addTextInput[text input ID;style;label;(minimum length;maximum length;required?
 > You can't add more than 5 text input fields.
 
 ### Parameters
-- `text input ID` `(Type: String || Flag: Required)`: ID that is used to retrieve the text input in the field. This value must be unique.
-- `style` `(Type: Enum || Flag: Required)`: The text input field style, either `short` or `paragraph`.
-- `label` `(Type: String || Flag: Required)`: Name of the text input field. This value must be less than or equal to 45 characters.
-- `minimum length` `(Type: Integer || Flag: Vacantable)`: Minimum number of characters a user needs to input. This value must be an integer between 0 and 4000, and can't be greater than the `maximum length`.
-- `maximum length` `(Type: Integer || Flag: Vacantable)`: Maximum number of characters a user can input. This value must be an integer between 0 and 4000, and can't be less than the `minimum length`.  
-- `required?` `(Type: Bool || Flag: Optional)`: Whether a user must fill in the text input field, defaults to true. (`yes`/`no`)
-- `value` `(Type: String || Flag: Vacantable)`: The text that is written by default in the text input field. This value must be less than or equal to 4000 characters and must not be less than `minimum length` and no more than `maximum length`.
-- `placeholder` `(Type: String || Flag: Vacantable)`: The text that is displayed if the text input field is empty. This value must be less than or equal to 100 characters.
+
+| Argument         | Description                                                                                                        | Type    | Flag       |
+|------------------|--------------------------------------------------------------------------------------------------------------------|---------|------------|
+| text input ID    | ID that is used to retrieve the text input in the field. This value must be unique.                                | String  | Required   |
+| style            | The text input field style, either `short` or `paragraph`.                                                         | Enum    | Required   |
+| label            | Name of the text input field. This value must be less than or equal to 45 characters.                              | String  | Required   |
+| minimum length   | Minimum number of characters a user needs to input. This value must be an integer between 0 and 4000, and can't be greater than the `maximum length`.  | Integer | Vacantable |
+| maximum length   | Maximum number of characters a user can input. This value must be an integer between 0 and 4000, and can't be less than the `minimum length`.  | Integer | Vacantable |
+| required?        | Whether a user must fill in the text input field, defaults to true. (`yes`/`no`)                                   | Bool    | Optional   |
+| value            | The text that is written by default in the text input field. This value must be less than or equal to 4000 characters and must not be less than `minimum length` and no more than `maximum length`. | String  | Vacantable |
+| placeholder      | The text that is displayed if the text input field is empty. This value must be less than or equal to 100 characters. | String  | Vacantable |
+
+
 
 ### Styles
 - `short` and `paragraph`.

--- a/src/bdscript/addTimestampComplex.md
+++ b/src/bdscript/addTimestampComplex.md
@@ -7,7 +7,11 @@ $addTimestamp[index]
 ```
 
 ### Parameters
-- `index` `(Type: Integer || Flag: Optional)`: To which embed the timestamp should be added to. [(learn more)](../resources/embedIndexes.md)
+
+| Argument | Description                                                                                                        | Type    | Flag       |
+|----------|--------------------------------------------------------------------------------------------------------------------|---------|------------|
+| index    | To which embed the timestamp should be added to. [(learn more)](../resources/embedIndexes.md)                      | Integer | Optional   |
+
 
 ## Example
 ```

--- a/src/bdscript/allowRoleMentions.md
+++ b/src/bdscript/allowRoleMentions.md
@@ -7,7 +7,11 @@ $allowRoleMentions[role IDs;...]
 ```
 
 ### Parameters
-- `role IDs` `(Type: Snowflake || Flag: Emptiable)`: The roles that can be pinged, leave empty to disable pings for every role. Separate role IDs using `;`.
+
+| Argument  | Description                                                                      | Type      | Flag      |
+|-----------|----------------------------------------------------------------------------------|-----------|-----------|
+| role IDs  | The roles that can be pinged, leave empty to disable pings for every role. Separate role IDs using `;`. | Snowflake | Emptiable |
+
 
 ## Example
 ```

--- a/src/bdscript/allowUserMentions.md
+++ b/src/bdscript/allowUserMentions.md
@@ -7,7 +7,11 @@ $allowUserMentions[user IDs;...]
 ```
 
 ### Parameters
-- `user IDs` `(Type: Snowflake || Flag: Emptiable)`: The users that can be pinged, leave empty to disable pings for every user. Separate user IDs using `;`.
+
+| Argument  | Description                                                                      | Type      | Flag      |
+|-----------|----------------------------------------------------------------------------------|-----------|-----------|
+| user IDs  | The users that can be pinged, leave empty to disable pings for every user. Separate user IDs using `;`. | Snowflake | Emptiable |
+
 
 ## Example
 ```

--- a/src/bdscript/and.md
+++ b/src/bdscript/and.md
@@ -7,7 +7,11 @@ $and[conditions;...]
 ```
 
 ### Parameters
-- `conditions` `(Type: String || Flag: Required)`: Checks that will be carried out. All conditions must be true for this function to return `true`. Separate conditions using `;`.
+
+| Argument    | Description                                                                                                  | Type   | Flag     |
+|-------------|--------------------------------------------------------------------------------------------------------------|--------|----------|
+| conditions  | Checks that will be carried out. All conditions must be true for this function to return `true`. Separate conditions using `;`. | String | Required |
+
 
 ### Signs
 `==` - Equal

--- a/src/bdscript/argCount.md
+++ b/src/bdscript/argCount.md
@@ -7,7 +7,11 @@ $argCount[text]
 ```
 
 ### Parameters
-- `text` `(Type: String || Flag: Emptiable)`: The text to get word count for.
+
+| Argument | Description                      | Type   | Flag     |
+|----------|----------------------------------|--------|----------|
+| text     | The text to get word count for.  | String | Emptiable |
+
 
 ## Example
 ```

--- a/src/bdscript/argsCheck.md
+++ b/src/bdscript/argsCheck.md
@@ -7,9 +7,15 @@ $argsCheck[how many?;error message]
 ```
 
 ### Parameters
-- `how many?` `(Type: HowMany || Flag: Required)`: How many arguments there should be in the user’s message.
+
+| Argument      | Description                                                   | Type     | Flag     |
+|---------------|---------------------------------------------------------------|----------|----------|
+| how many?     | How many arguments there should be in the user's message.     | HowMany  | Required |
+| error message | The message that the bot will send if the user has too many/little arguments. | String | Emptiable |
+
+
+### Note :
    > If you want users to have 3 or more arguments in their message; you can use `>3`. If you want users to have less than 3 arguments in their message, you can use `<3`. If you want the users to have exactly 3 arguments in their message put `3`. 
-- `error message` `(Type: String || Flag: Emptiable)`: The message that the bot will send if the user has too many/little arguments.
 
 ## Example
 ```

--- a/src/bdscript/author.md
+++ b/src/bdscript/author.md
@@ -7,8 +7,12 @@ $author[text;(index)]
 ```
 
 ### Parameters
-- `text` `(Type: String || Flag: Emptiable)`: The text that appears in the author text. It cannot exceed more than 256 characters.
-- `index` `(Type: Integer || Flag: Optional)`: To which embed the author text will be added. [(learn more)](../resources/embedIndexes.md)
+
+| Argument | Description                                                      | Type    | Flag     |
+|----------|------------------------------------------------------------------|---------|----------|
+| text     | The text that appears in the author text. It cannot exceed more than 256 characters. | String  | Emptiable |
+| index    | To which embed the author text will be added. [(learn more)](../resources/embedIndexes.md) | Integer | Optional |
+
 
 ## Example
 ```

--- a/src/bdscript/authorIcon.md
+++ b/src/bdscript/authorIcon.md
@@ -5,11 +5,17 @@ Adds an icon to the author section in the embed.
 ```
 $authorIcon[image url;(index)]
 ```
-> `$authorIcon[]` will not work if there is no text provided in `$author[]`.
 
 ### Parameters
-- `image url` `(Type: URL || Flag: Emptiable)`: The image for the author icon. This must be a valid image URL.
-- `index` `(Type: Integer || Flag: Optional)`: To which embed the author icon will be added. [(learn more)](../resources/embedIndexes.md)
+
+| Argument  | Description                                                    | Type    | Flag     |
+|-----------|----------------------------------------------------------------|---------|----------|
+| image url | The image for the author icon. This must be a valid image URL. | URL     | Emptiable |
+| index     | To which embed the author icon will be added. [(learn more)](../resources/embedIndexes.md) | Integer | Optional |
+
+
+### Note :
+> `$authorIcon[]` will not work if there is no text provided in `$author[]`.
 
 ## Example
 ```

--- a/src/bdscript/authorOfMessage.md
+++ b/src/bdscript/authorOfMessage.md
@@ -7,8 +7,12 @@ $authorOfMessage[channel ID;message ID]
 ```
 
 ### Parameters
-- `channel ID` `(Type: Snowflake || Flag: Required)`: The channel where the message was sent in.
-- `message ID` `(Type: Snowflake || Flag: Required)`: The message for which the author ID will be returned.
+
+| Argument   | Description                                           | Type      | Flag     |
+|------------|-------------------------------------------------------|-----------|----------|
+| channel ID | The channel where the message was sent in.            | Snowflake | Required |
+| message ID | The message for which the author ID will be returned. | Snowflake | Required |
+
 
 >  [How to get the message/channel ID guide.](https://support.discord.com/hc/en-us/articles/206346498-Where-can-I-find-my-User-Server-Message-ID-)
 

--- a/src/bdscript/authorURL.md
+++ b/src/bdscript/authorURL.md
@@ -5,11 +5,17 @@ Adds a hyperlink to the author text.
 ```
 $authorURL[url;(index)]
 ```
-> `$authorURL[]` will not work if there is no text provided in `$author[]`.
 
 ### Parameters
-- `url` `(Type: URL || Flag: Emptiable)`: The link to set as the author hyperlink.
-- `index` `(Type: Integer || Flag: Optional)`: To which embed the author URL will be added. [(learn more)](../resources/embedIndexes.md)
+
+| Argument | Description                                 | Type    | Flag     |
+|----------|---------------------------------------------|---------|----------|
+| url      | The link to set as the author hyperlink.    | URL     | Emptiable |
+| index    | To which embed the author URL will be added. | Integer | Optional |
+
+
+### Note :
+> `$authorURL[]` will not work if there is no text provided in `$author[]`.
 
 ## Example
 ```

--- a/src/bdscript/awaitFunc.md
+++ b/src/bdscript/awaitFunc.md
@@ -7,9 +7,13 @@ $awaitFunc[name;(user ID;channel ID)]
 ```
 
 ### Parameters
-- `name` `(Type: String || Flag: Required)`: The name used inside [`$awaitedCommand[]`](../callbacks/awaitedCommand.md) and [`$awaitedCommandError[]`](../callbacks/awaitedCommandError.md) callbacks.
-- `user ID` `(Type: Snowflake || Flag: Vacantable)`: The user the awaited command will trigger for. Uses command author, if `user ID` is not given.
-- `channel ID` `(Type: Snowflake || Flag: Optional)`: The channel where the command will be awaited. Uses current channel, if `channel ID` is not given.
+
+| Argument   | Description                                                         | Type     | Flag       |
+|------------|---------------------------------------------------------------------|----------|------------|
+| name       | The name used inside `$awaitedCommand[]` and `$awaitedCommandError[]` callbacks. | String   | Required   |
+| user ID    | The user the awaited command will trigger for. Uses command author if `user ID` is not given. | Snowflake | Vacantable |
+| channel ID | The channel where the command will be awaited. Uses current channel if `channel ID` is not given. | Snowflake | Optional   |
+
 
 ## Example
 ```

--- a/src/callbacks/awaitedCommand.md
+++ b/src/callbacks/awaitedCommand.md
@@ -8,8 +8,12 @@ _Triggered when an awaited command gets initiated._
 $awaitedCommand[Name;(Filter)]
 ```
 ### Parameters
-- `Name` `(Type: String || Flag: Required)`: The name used in the [`$awaitFunc[]`](../bdscript/awaitFunc.md) function.
-- `Filter` `(Type: String || Flag: Optional)`: It is used to limit the user input.
+
+| Argument | Description                                                     | Type   | Flag     |
+|----------|-----------------------------------------------------------------|--------|----------|
+| Name     | The name used in the [`$awaitFunc[]`](../bdscript/awaitFunc.md) function.                     | String | Required |
+| Filter   | It is used to limit the user input.                               | String | Optional |
+
 
 ### Supported filters
 - `<numeric>` - Accepts only number input.

--- a/src/callbacks/awaitedCommandError.md
+++ b/src/callbacks/awaitedCommandError.md
@@ -9,7 +9,11 @@ $awaitedCommandError[Name]
 ```
 
 ### Parameters
-- `Name` `(Type: String || Flag: Required)`: The name used in the [`$awaitFunc[]`](../bdscript/awaitFunc.md) function.
+
+| Argument | Description                                   | Type   | Flag     |
+|----------|-----------------------------------------------|--------|----------|
+| Name     | The name used in the [`$awaitFunc[]`](../bdscript/awaitFunc.md) function. | String | Required |
+
 
 ## Example
 **Trigger: `$awaitedCommandError[number]`**

--- a/src/callbacks/onBanAdd.md
+++ b/src/callbacks/onBanAdd.md
@@ -9,7 +9,11 @@ $onBanAdd[channelID]
 ```
 
 ### Parameters
-- `channelID` `(Type: Snowflake || Flag: Required)`: The ID of the channel where the message should be sent to.
+
+| Argument   | Description                                             | Type     | Flag     |
+|------------|---------------------------------------------------------|----------|----------|
+| channelID  | The ID of the channel where the message should be sent to. | Snowflake | Required |
+
 
 ## Example
 1. Create a command with `$onBanAdd[channelID]` as the trigger.

--- a/src/callbacks/onBanRemove.md
+++ b/src/callbacks/onBanRemove.md
@@ -9,7 +9,11 @@ $onBanRemove[channelID]
 ```
 
 ### Parameters
-- `channelID` `(Type: Snowflake || Flag: Required)`: The ID of the channel where the message should be sent to.
+
+| Argument   | Description                                             | Type     | Flag     |
+|------------|---------------------------------------------------------|----------|----------|
+| channelID  | The ID of the channel where the message should be sent to. | Snowflake | Required |
+
 
 ## Example
 1. Create a command with `$onBanRemove[channelID]` as the trigger.

--- a/src/callbacks/onInteractionComplex.md
+++ b/src/callbacks/onInteractionComplex.md
@@ -7,7 +7,11 @@ $onIneraction[Interaction ID]
 ```
 
 ### Parameters
-- `Interaction ID` `(Type: String || Flag: Required)`: The custom/menu/button/interaction ID used during the creation of buttons, menus, text fields, and other components.
+
+| Argument       | Description                                                                                             | Type   | Flag     |
+|----------------|---------------------------------------------------------------------------------------------------------|--------|----------|
+| Interaction ID | The custom/menu/button/interaction ID used during the creation of buttons, menus, text fields, and other components. | String | Required |
+
 
 ### Supports
 - **[Buttons](../guides/general/interactions/buttons/aboutButtons.md)**

--- a/src/callbacks/onJoined.md
+++ b/src/callbacks/onJoined.md
@@ -11,7 +11,10 @@ $onJoined[channelID]
 ```
 
 ### Parameters
-- `channelID` `(Type: Snowflake || Flag: Required)`: The ID of the channel where the message should be sent to.
+
+| Argument   | Description                                             | Type     | Flag     |
+|------------|---------------------------------------------------------|----------|----------|
+| channelID  | The ID of the channel where the message should be sent to. | Snowflake | Required |
 
 ## Example
 1. Create a command with the trigger `$onJoined[channelID]`.

--- a/src/callbacks/onLeave.md
+++ b/src/callbacks/onLeave.md
@@ -11,7 +11,10 @@ $onLeave[channelID]
 ```
 
 ### Parameters
-- `channelID` `(Type: Snowflake || Flag: Required)`: The ID of the channel where the message should be sent to.
+
+| Argument   | Description                                             | Type     | Flag     |
+|------------|---------------------------------------------------------|----------|----------|
+| channelID  | The ID of the channel where the message should be sent to. | Snowflake | Required |
 
 ## Example
 1. Create a command with the trigger `$onLeave[channelID]`.

--- a/src/callbacks/onMessageDelete.md
+++ b/src/callbacks/onMessageDelete.md
@@ -9,7 +9,9 @@ $onMessageDelete[channelID]
 ```
 
 ### Parameters
-- `channelID` `(Type: Snowflake || Flag: Required)`: The channel to which the resulting message will be sent.
+| Argument   | Description                                             | Type     | Flag     |
+|------------|---------------------------------------------------------|----------|----------|
+| channelID  | The channel to which the resulting message will be sent. | Snowflake | Required |
 
 ## Example
 1. Create a command with the trigger `$onMessageDelete[channelID]`.

--- a/src/guides/other/arguments.md
+++ b/src/guides/other/arguments.md
@@ -1,31 +1,34 @@
-## Argument Flags
-Function argument flags mark how arguments within a function may be used (or hence, not used at all), it will be displayed near or below the function argument.
-Example: (- `userID` `(Flag: Required)`) etc.
+# Argument Flags
+Function argument flags indicate how arguments within a function may be used, or if they are optional or required.
 
-- __Optional__ - The argument **can** be excluded but **cannot** be left empty, they show up as `(something)` and will **always** be after all required arguments.
-- __Required__ - The argument **must** be included and **cannot** be empty.
-- __Emptiable__ - The argument **must** be included but **can** be empty.
-- __Vacantable__ - The argument **can** be excluded and if included **can** be empty.
+| Flags        | Description                                                                                           |
+|--------------|-------------------------------------------------------------------------------------------------------|
+| Optional     | The argument can be excluded, but cannot be left empty. It is displayed as `(something)` in usage.    |
+| Required     | The argument must be included and cannot be empty.                                                     |
+| Emptiable    | The argument must be included, but can be empty.                                                        |
+| Vacantable   | The argument can be excluded, and if included, it can be empty.                                        |
 
+# Argument Types
+This section explains the various argument types used for function arguments. Arguments are values placed within `[]` in a function, and they are displayed near or below the function.
 
-## Argument Types
-This section will explain the various argument types used for function arguments. Function arguments are anything that goes in the brackets `[]` of a function, it will be displayed near or below the function argument.
-Example: (- `userID` `(Type: Snowflake || Flag: Required)`) and if it has more than one option it will be `(Type: String, Snowflake || Flag: Required)` etc.
+| Types        | Description                                                                                           |
+|--------------|-------------------------------------------------------------------------------------------------------|
+| String       | A general-purpose argument that can contain any characters or text.                                   |
+| Snowflake    | A valid Discord ID, such as a role, channel, user, server, emoji, or message.                         |
+| Integer      | A whole number without a decimal point (e.g., -5, -1, 1, 5, 10, etc.).                                |
+| Float        | A number with a decimal point (e.g., -2.5, -0.5, 1.5, 5.2, 7.30, etc.).                                |
+| URL          | A valid URL with the prefix `http://` or `https://` and a valid domain name.                          |
+| HowMany      | A number that can be prefixed or suffixed with `<` or `>`, or a plain integer.                        |
+| Enum         | Strings that match specific key values (case insensitive).                                            |
+| Emoji        | An emoji represented as 🌹 or in the format `<a:emoji_name:emoji-id>` for gif emojis and `<:emoji_name:emoji-id>` for non-gif emojis. |
+| Duration     | A time-based duration, represented by an integer followed by a valid time format (s, m, h, d, w).      |
+| Permission   | A Discord permission (case insensitive). See [here](../../resources/permissions.md) for valid permissions. |
+| Bool         | A boolean value represented as yes/no or true/false.                                                  |
+| Color        | A color hex code, which can be obtained from [here](https://htmlcolorcodes.com/color-picker), for example. |
 
-- __String__ - This is the most generalized function, a string can be any character or text.
-- __Snowflake__ - A valid discord ID, can be of a role, channel, user, server, emoji and message.
-- __Integer__ - Any number without decimal (-5, -1, 1, 5 10, etc).
-- __Float__ - A number with decimal (-2.5, -0.5, 1.5, 5.2, 7.30, etc).
-- __URL__ - A valid domain link, **must** be prefixed by `http://` or `https://` and have a valid domain name.
-- __HowMany__ - A number that is prefixed or suffixed with < or >, or just a plain integer.
-- __Enum__ - Strings that match a certain key value (case insensitive).
-- __Emoji__ - Emoji as 🌹 or the discord custom emojis in form of `<a:emoji_name:emoji-id>` for gif emojis and `<:emoji_name:emoji-id>` for non-gif emojis, for how to get that, check [$addReactions](../../bdscript/addReactions.md) as it has explanations for that. Characters `<>` can be omitted from the discord custom emoji form.
-- __Duration__ - A time based duration, an integer suffixed with a valid time format (s, m, h, d, w).
-- __Permission__ - Discord permission (case insensitive), see [this](../../resources/permissions.md) for all valid permissions.
-- __Bool__ - yes/no or true/false.
-- __Color__ - Color Hex Code you can get from [here](https://htmlcolorcodes.com/color-picker) as an example
+# Argument Pairs
 
-
-## Pairs
-- __Tuple__ - A tuple is a set of arguments that depend on others to function, they are shown with `<>` on either side.
-- __Ellipsis__ - Ellipsis notations (`...`) symbolize an argument that can be repeated multiple times. Ellipsis is denoted with `...` as the argument after the argument which can be repeated.
+| Pairs        | Description                                                                                           |
+|--------------|-------------------------------------------------------------------------------------------------------|
+| Tuple        | A set of arguments that depend on each other to function, displayed with `<>` on either side.         |
+| Ellipsis     | Ellipsis notation (`...`) represents an argument that can be repeated multiple times.                 |

--- a/src/premium/awaitReactions.md
+++ b/src/premium/awaitReactions.md
@@ -9,8 +9,11 @@ $awaitReactions[<Command name;Reaction>;...]
 ```
 
 ### Parameters
-- `Command name` `(Type: String || Flag: Required)`: The name which will be used inside the `$reaction[]` callback.
-- `Reaction` `(Type: Emoji || Flag: Required)`: The reaction to await. The reaction must be either a Unicode Emoji or a Discord custom emoji id.
+
+| Argument       | Description                                                                                      | Type    | Flag     |
+|----------------|--------------------------------------------------------------------------------------------------|---------|----------|
+| Command name   | It's the name which will be used inside the `$reaction[]` callback.                              | String  | Required |
+| Reaction       | It awaits the given emoji. Emoji must be either in Unicode or in Discord emoji ID format.        | Emoji   | Required |
 
 ## Example
 ```

--- a/src/premium/awaitedReactions.md
+++ b/src/premium/awaitedReactions.md
@@ -19,10 +19,13 @@ $awaitReactions[<Command name;Reaction>;...]
 ```
 
 #### Parameters
-- `Command name` `(Type: String || Flag: Required)`: It's the name which will be used inside the `$reaction[]` callback.
-- `Reaction` `(Type: Emoji || Flag: Required)`: It awaits the given emoji. Emoji must be either in Unicode or in Discord emoji ID format.
 
+| Argument       | Description                                                                                      | Type    | Flag     |
+|----------------|--------------------------------------------------------------------------------------------------|---------|----------|
+| Command name   | It's the name which will be used inside the `$reaction[]` callback.                              | String  | Required |
+| Reaction       | It awaits the given emoji. Emoji must be either in Unicode or in Discord emoji ID format.        | Emoji   | Required |
 
+### Note :
 > 📝 You can group reactions by specifying more *"command names"* and *"reactions"* in `$awaitReactions[]`.\
 \
 > ⚠️ In group reactions, when one reaction is used, the others stop working i.e let's say, a command awaits two reactions (✔️ & ❌). If the user reacts ✔️ then ❌ stops working.
@@ -36,7 +39,11 @@ $reaction[Name]
 ```
 
 #### Parameters
-- `Name` `(Type: String || Flag: Required)`: It's the value which is used in the *"command name"* argument of `$awaitReactions[]`.
+
+| Argument | Description                                                                   | Type   | Flag     |
+|----------|-------------------------------------------------------------------------------|--------|----------|
+| Name     | It's the value which is used in the "command name" argument of `$awaitReactions[]`. | String | Required |
+
 
 ## $usedEmoji
 This function is used to return the emoji which was triggered in the `$reaction[]` command.

--- a/src/premium/customImage.md
+++ b/src/premium/customImage.md
@@ -9,7 +9,11 @@ $customImage[Custom image tag]
 ```
 
 ### Parameters
-- `Custom image tag` `(Type: String || Flag: Required)`: The image tag you set in the app while uploading the image.
+
+| Argument           | Description                                                              | Type   | Flag     |
+|--------------------|--------------------------------------------------------------------------|--------|----------|
+| Custom image tag   | The image tag you set in the app while uploading the image.               | String | Required |
+
 
 ## Example
 ```

--- a/src/premium/customImages.md
+++ b/src/premium/customImages.md
@@ -29,7 +29,11 @@ $customImage[Custom image tag]
 ```
 
 #### Parameters
-- `Custom image tag` `(Type: String || Flag: Required)`: The tag that you set the custom image to, previously.
+
+| Argument           | Description                                                              | Type   | Flag     |
+|--------------------|--------------------------------------------------------------------------|--------|----------|
+| Custom image tag   | The tag that you set the custom image to, previously.               | String | Required |
+
 
 #### Example
 ```

--- a/src/premium/messageContains.md
+++ b/src/premium/messageContains.md
@@ -9,7 +9,11 @@ $messageContains[Word;...]
 ```
 
 ### Parameters
-- `Word` `(Type: String || Flag: Required)`: The phrases/words the bot checks for. Separate phrases using `;`.
+
+| Argument | Description                                          | Type   | Flag     |
+|----------|------------------------------------------------------|--------|----------|
+| Word     | The phrases/words the bot checks for. Separate phrases using `;`. | String | Required |
+
 
 ## Example
 1. Create a new command with command trigger set as `$messageContains[]`.

--- a/src/premium/reaction.md
+++ b/src/premium/reaction.md
@@ -9,7 +9,10 @@ $reaction[Name]
 ```
 
 ### Parameters
-- `Name` `(Type: String || Flag: Required)`: The value used in "command name" argument of `$awaitReactions[]`.
+
+| Argument | Description                                                                   | Type   | Flag     |
+|----------|-------------------------------------------------------------------------------|--------|----------|
+| Name     | It's the value which is used in the "command name" argument of `$awaitReactions[]`. | String | Required |
 
 ## Example
 ### Trigger `$reaction[click]`

--- a/src/premium/sendNotification.md
+++ b/src/premium/sendNotification.md
@@ -9,8 +9,12 @@ $sendNotification[Message;(Image URL)]
 ```
 
 ### Parameters 
-- `Message` `(Type: String || Flag: Required)`: The text that is displayed in the notification.
-- `Image URL` `(Type: String || Flag: Optional)`: The URL for the image to be attached.
+
+| Argument   | Description                                          | Type   | Flag     |
+|------------|------------------------------------------------------|--------|----------|
+| Message    | The text that is displayed in the notification.       | String | Required |
+| Image URL  | The URL for the image to be attached.                 | String | Optional |
+
 
 ## Example
 ```


### PR DESCRIPTION
The `arguments.md` file has been updated with the revised table structure that includes the content description.
The `$a` functions and `callbacks` have also been updated with their respective tables, presenting the content description instead of `(Type: || Flag:)`.
The `premium` section has been updated with a new table format reflecting the content details instead of `(Type: || Flag:)`.