### PR TITLE
fix: example code error

### DIFF
--- a/src/bdscript/editSplitText.md
+++ b/src/bdscript/editSplitText.md
@@ -20,12 +20,14 @@ $var[Index;$splitText[$sub[$getTextSplitLength;1]]]
 $var[Value;$splitText[$getTextSplitLength]]
 
 $removeSplitTextElement[$getTextSplitLength]
-$removeSplitTextElement[$sub[$getTextSplitLength;1]]
+$removeSplitTextElement[$getTextSplitLength]
 
-$textSplit[$joinSplitText[ ];]
+$var[Text;$joinSplitText[ ]]
+
+$textSplit[$var[Text];]
 $editSplitText[$var[Index];$var[Value]]
 
-Original Text: $joinSplitText[ ]
+Original Text: $var[Text]
 New Text: $joinSplitText[]
 ```
 ![example](https://user-images.githubusercontent.com/95774950/202880969-9ce5041a-cc6c-4bd2-a275-76e9d80be5b5.png)


### PR DESCRIPTION
At the time of writing the `$editSplitText[]` wiki page. The example code was working fine but recently this code returns an error now.

![Screenshot_20230607_170129](https://github.com/NilPointer-Software/bdfd-wiki/assets/95774950/077d002c-2dbf-44c3-bbdd-6f7eacab89f1)

Thanks to @oriel-beck for notifying about this!