### PR TITLE
Fix redirects for select menu and error handling

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -31,11 +31,9 @@ level = 0
 #buttons
 "/guides/buttons.html" = "./general/interactions/buttons/aboutButtons.html"
 #select menu (based on my archived guides, the old path for errorHandling and selectMenus aren't in camelCase. ~Carmen)
-"/guides/selectmenu.html" = "./general/interactions/selectMenus/aboutSelectMenu.html"
-"/guides/selectMenu.html" = "./general/interactions/selectMenus/aboutSelectMenu.html"
+"/selectmenu.html" = "./guides/general/interactions/selectMenus/aboutSelectMenu.html"
 #error handling
-"/guides/trycatch.html" = "./general/bds2/errorHandling.html"
-"/guides/tryCatch.html" = "./general/bds2/errorHandling.html"
+"/trycatch.html" = "./guides/general/bds2/errorHandling.html"
 #premium functions
 "/bdscript/awaitReactions.html" = "../premium/awaitReactions.html"
 "/bdscript/customImage.html" = "../premium/customImage.html"


### PR DESCRIPTION
Turns out the app doesn't redirect to /guides for those categories 

I just figured out I can drag-and-drop the `Page not found` to check what page the app is still using
![20230715_184909](https://github.com/NilPointer-Software/bdfd-wiki/assets/115384748/b1dc2529-6b05-4a9e-bd05-21bb1a116bdc)

(I was right about the old link though, it's just the app doesn't go to /guides somewhy lol)