### PR TITLE
Update premium introduction.md

### DIFF
--- a/src/premium/introduction.md
+++ b/src/premium/introduction.md
@@ -34,9 +34,9 @@ After a successful purchase of premium points, here's how to redeem them :
 - Access to [`$messageContains[]`](./messageContains.md) and [`$alwaysReply`](./alwaysReply.md) callbacks.
 - Custom images.
 - Access to [`$ignoreTriggerCase`](./ignoreTriggerCase.md) and [`$sendNotification`](./sendNotification.md) functions.
-- Unlimited commands/variables.
+- Unlimited commands and variables.
 - Ad-free hosting time.
-- Priority bot hosting/startup.
+- Priority bot hosting and startup.
 - Maximum 120 minutes duration in `$replyIn` & `$editEmbedIn`.
 - Increased server and global variable character limits.
 - Bot guild list.


### PR DESCRIPTION
It used to say, "Unlimited commands/variables" and "Priority bot hosting/startup."
I have updated it to say, "Unlimited commands and variables" and "Priority bot hosting and startup" which makes more sense and doesn't give any confusion because the slash may be taken as 'or', reading it as "Unlimited commands or variables."