### PR TITLE
fix(ci/cd): missing components in Discord webhook notification

### DIFF
--- a/.github/workflows/book_deploy.yml
+++ b/.github/workflows/book_deploy.yml
@@ -142,12 +142,12 @@ jobs:
               **__Content__**
 
               ${{ env.MESSAGE }}
-            component:
-              - type: 2
-                style: 5
-                label: View commit
-                url: ${{ github.event.head_commit.url }}
-              - type: 2
-                style: 5
-                label: Preview site
-                url: https://nilpointer-software.github.io/bdfd-wiki/${{ env.LINK }}
+          component: |-
+            - type: 2
+              style: 5
+              label: View commit
+              url: ${{ github.event.head_commit.url }}
+            - type: 2
+              style: 5
+              label: Preview site
+              url: https://nilpointer-software.github.io/bdfd-wiki/${{ env.LINK }}


### PR DESCRIPTION
Earlier, the Discord webhook notification message used to include components but now, it doesn't. This PR fixes this minor issue caused from #413 .

Please, refer to [`#wiki-updates`](https://discord.com/channels/566363823137882154/1005952793342918696)  channel in the server and compare these 2 messages to know the difference:

- [Message 1](https://discord.com/channels/566363823137882154/1005952793342918696/1261717681464148050)
- [Message 2](https://discord.com/channels/566363823137882154/1005952793342918696/1261718720183537688)