### PR TITLE
Add redirects for interaction guides

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -42,6 +42,8 @@ assets_version = "3.0.2" # do not edit: managed by `mdbook-admonish install`
 [output.html.redirect]
 "/guides/ifStatements.html" = "./general/ifStatements.html"
 "/guides/async.html" = "./general/bds2/asyncScopes.html"
+"/guides/buttons.html" = "./general/interactions/buttons/aboutButtons.html"
+"/guides/selectmenu.html" = "./general/interactions/selectMenus/aboutSelectMenu.html"
 
 "/bdscript/httpAddHeader.html" = "../guides/general/httpRequests.html"
 "/bdscript/httpDelete.html" = "../guides/general/httpRequests.html"

--- a/book.toml
+++ b/book.toml
@@ -44,6 +44,7 @@ assets_version = "3.0.2" # do not edit: managed by `mdbook-admonish install`
 "/guides/async.html" = "./general/bds2/asyncScopes.html"
 "/guides/buttons.html" = "./general/interactions/buttons/aboutButtons.html"
 "/guides/selectmenu.html" = "./general/interactions/selectMenus/aboutSelectMenu.html"
+"/guides/try.html" = "./general/bds2/errorHandling.html"
 
 "/bdscript/httpAddHeader.html" = "../guides/general/httpRequests.html"
 "/bdscript/httpDelete.html" = "../guides/general/httpRequests.html"


### PR DESCRIPTION
can't directly see the old url in app but I got them from the logged network traffic
<img width="1169" height="74" alt="image" src="https://github.com/user-attachments/assets/026652a2-2bbf-4409-ae83-94205ee15b01" />
<img width="1149" height="96" alt="image" src="https://github.com/user-attachments/assets/fdfa0855-3187-4eb9-b28e-2de2fe6829f9" />
<img width="780" height="76" alt="image" src="https://github.com/user-attachments/assets/72a599d1-272c-4a34-9028-5986671e45f1" />
