### PR TITLE
fix: correct typos and grammar across wiki

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ Some of the frequently asked questions from users -
 
 ### Shortening Headers
 
-Always keep section headers short, consise, and in [Title Case](https://en.m.wikipedia.org/wiki/Title_case) format. For example,
+Always keep section headers short, concise, and in [Title Case](https://en.m.wikipedia.org/wiki/Title_case) format. For example,
 
 ```diff
 - How to create embeds
@@ -243,7 +243,7 @@ To test your custom code block, you can use the [official test site](https://nil
 - user_id: 154148273307910144
   username: MineBartekSA
   content: |
-      You can embed links by using the <code>a</code> HTML tag with the <code>href</code> attrubute: <a href="https://nilpointer-software.github.io/mdbook-discord-components/">Test site</a>
+      You can embed links by using the <code>a</code> HTML tag with the <code>href</code> attribute: <a href="https://nilpointer-software.github.io/mdbook-discord-components/">Test site</a>
 - user_id: 154148273307910144
   username: MineBartekSA
   content: " "
@@ -251,7 +251,7 @@ To test your custom code block, you can use the [official test site](https://nil
       title: Embed Text Formatting
       color: "#00FFFF"
       description: |
-          <i>Italics</i>, <b>Bold</b>, <del>Line-Truough</del>, <u>Underline</u>, <a href="https://nilpointer-software.github.io/mdbook-discord-components/">Links</a>, and <code>Code Snippets</code> use the same HTML tags.
+          <i>Italics</i>, <b>Bold</b>, <del>Line-Through</del>, <u>Underline</u>, <a href="https://nilpointer-software.github.io/mdbook-discord-components/">Links</a>, and <code>Code Snippets</code> use the same HTML tags.
 
           Embeds can contain multiline code blocks.
           Add a <code>multiline</code> class to a <code>code</code> HTML tag:
@@ -263,7 +263,7 @@ To test your custom code block, you can use the [official test site](https://nil
           <span class="spoiler">Spoiler</span>
 ```
 
-> Please note, that the empty `content` filed in the message with embed is a bug that will be resolved.
+> Please note, that the empty `content` field in the message with embed is a bug that will be resolved.
 
 -   On our wiki, messages can use the `user_id` yaml field for automatic and up-to-date avatar and username.
     When using `user_id`, the `username` field is no longer required and will overwrite the username fetched from Discord.

--- a/src/bdscript/addButton.md
+++ b/src/bdscript/addButton.md
@@ -122,5 +122,5 @@ $addButton[no;test;Say hello!;primary;no;]
 ```
 
 ```admonish info title="Read more"
-For more information, read the the [Buttons Guide](../guides/general/interactions/buttons/aboutButtons.md).
+For more information, read the [Buttons Guide](../guides/general/interactions/buttons/aboutButtons.md).
 ```

--- a/src/bdscript/and.md
+++ b/src/bdscript/and.md
@@ -86,5 +86,5 @@ How [`$message`](./message.md) and [`$nickname`](./nickname.md) works?
 ```
 
 ```admonish info title="Read more"
-For more information, read the the [If Statements Guide](../guides/ifStatements.md).
+For more information, read the [If Statements Guide](../guides/ifStatements.md).
 ```

--- a/src/bdscript/awaitFunc.md
+++ b/src/bdscript/awaitFunc.md
@@ -34,5 +34,5 @@ $awaitFunc[say]
 ```
 
 ```admonish info title="Read more"
-For more information, read the the [Awaited Commands Guide](../guides/general/awaitedCommands.md).
+For more information, read the [Awaited Commands Guide](../guides/general/awaitedCommands.md).
 ```

--- a/src/bdscript/editButton.md
+++ b/src/bdscript/editButton.md
@@ -90,5 +90,5 @@ $addButton[no;http://botdesignerdiscord.com;Check our website;link;no;👀]
 ![](https://user-images.githubusercontent.com/16838075/120207246-7d366b00-c22c-11eb-8d04-9cf569ced8ae.png)
 
 ```admonish info title="Read more"
-For more information, read the the [Buttons Guide](../guides/general/interactions/buttons/aboutButtons.md).
+For more information, read the [Buttons Guide](../guides/general/interactions/buttons/aboutButtons.md).
 ```

--- a/src/bdscript/else.md
+++ b/src/bdscript/else.md
@@ -42,5 +42,5 @@ $endif
 ```
 
 ```admonish info title="Read more"
-For more information, read the the [If Statements Guide](../guides/ifStatements.md).
+For more information, read the [If Statements Guide](../guides/ifStatements.md).
 ```

--- a/src/bdscript/elseif.md
+++ b/src/bdscript/elseif.md
@@ -66,5 +66,5 @@ $endif
 ```
 
 ```admonish info title="Read more"
-For more information, read the the [If Statements Guide](../guides/ifStatements.md).
+For more information, read the [If Statements Guide](../guides/ifStatements.md).
 ```

--- a/src/bdscript/endif.md
+++ b/src/bdscript/endif.md
@@ -46,5 +46,5 @@ $endif
 
 
 ```admonish info title="Read more"
-For more information, read the the [If Statements Guide](../guides/ifStatements.md).
+For more information, read the [If Statements Guide](../guides/ifStatements.md).
 ```

--- a/src/bdscript/getChannelVar.md
+++ b/src/bdscript/getChannelVar.md
@@ -32,5 +32,5 @@ Command used `$getChannelVar[Uses]` times in this channel
 ```
 
 ```admonish info title="Read more"
-For more information, read the the [Variables Guide](../guides/introduction/variables.md).
+For more information, read the [Variables Guide](../guides/introduction/variables.md).
 ```

--- a/src/bdscript/if.md
+++ b/src/bdscript/if.md
@@ -58,5 +58,5 @@ $endif
 ```
 
 ```admonish info title="Read more"
-For more information, read the the [If Statements Guide](../guides/ifStatements.md).
+For more information, read the [If Statements Guide](../guides/ifStatements.md).
 ```

--- a/src/bdscript/or.md
+++ b/src/bdscript/or.md
@@ -82,5 +82,5 @@ $or[$nickname==MineBartekSA;$message==Update]
 ```
 
 ```admonish info title="Read more"
-For more information, read the the [If Statements Guide](../guides/ifStatements.md).
+For more information, read the [If Statements Guide](../guides/ifStatements.md).
 ```

--- a/src/bdscript/setUserVar.md
+++ b/src/bdscript/setUserVar.md
@@ -15,5 +15,5 @@ $setUserVar[Variable name;New value;(User ID;Guild ID)]
 > 📝 User variable values have a max character limit of **4999**.
 
 ```admonish info title="Read more"
-For more information, read the the [Variables Guide](../guides/introduction/variables.md).
+For more information, read the [Variables Guide](../guides/introduction/variables.md).
 ```

--- a/src/bdscript/shardID.md
+++ b/src/bdscript/shardID.md
@@ -28,5 +28,5 @@ Shard: $shardID
 ```
 
 ```admonish info title="Read more"
-For more information, read the the ["Sharding" article](../resources/sharding.md).
+For more information, read the ["Sharding" article](../resources/sharding.md).
 ```

--- a/src/bdscript/shardIDComplex.md
+++ b/src/bdscript/shardIDComplex.md
@@ -35,5 +35,5 @@ How [`$message`](./message.md) works?
 ```
 
 ```admonish info title="Read more"
-For more information, read the the ["Sharding" article](../resources/sharding.md).
+For more information, read the ["Sharding" article](../resources/sharding.md).
 ```

--- a/src/bdscript/threadMessageCount.md
+++ b/src/bdscript/threadMessageCount.md
@@ -1,5 +1,5 @@
 # $threadMessageCount
-Returns the total number of users in the current thread. (**not including bot's response**)
+Returns the total number of messages in the current thread. (**not including bot's response**)
 
 ## Syntax
 ```

--- a/src/bdscript/var.md
+++ b/src/bdscript/var.md
@@ -32,5 +32,5 @@ $addButton[no;interactionID;Example;secondary;;;$var[ID]]
 ![Example](https://user-images.githubusercontent.com/70456337/189480166-d37cbdb8-05ce-44e8-8f2e-14d030baa9a9.png)
 
 ```admonish info title="Read more"
-For more information, read the the [Variables Guide](../guides/introduction/variables.md).
+For more information, read the [Variables Guide](../guides/introduction/variables.md).
 ```

--- a/src/bdscript/varExistError.md
+++ b/src/bdscript/varExistError.md
@@ -45,5 +45,5 @@ You are now cool!
 ```
 
 ```admonish info title="Read more"
-For more information, read the the [Variables Guide](../guides/introduction/variables.md).
+For more information, read the [Variables Guide](../guides/introduction/variables.md).
 ```

--- a/src/bdscript/varExists.md
+++ b/src/bdscript/varExists.md
@@ -46,5 +46,5 @@ How [`$message`](./message.md) works?
 ```
 
 ```admonish info title="Read more"
-For more information, read the the [Variables Guide](../guides/introduction/variables.md).
+For more information, read the [Variables Guide](../guides/introduction/variables.md).
 ```

--- a/src/bdscript/variablesCount.md
+++ b/src/bdscript/variablesCount.md
@@ -31,5 +31,5 @@ $variablesCount[server]
 ```
 
 ```admonish info title="Read more"
-For more information, read the the [Variables Guide](../guides/introduction/variables.md).
+For more information, read the [Variables Guide](../guides/introduction/variables.md).
 ```

--- a/src/bdscript/webhookAvatarURL.md
+++ b/src/bdscript/webhookAvatarURL.md
@@ -38,5 +38,5 @@ How [`$webhookCreate[]`](./webhookCreate.md), [`$channelID`](./channelID.md), [`
 ```
 
 ```admonish info title="Read more"
-For more information, read the the [Webhooks Guide](../guides/general/webhooks.md).
+For more information, read the [Webhooks Guide](../guides/general/webhooks.md).
 ```

--- a/src/bdscript/webhookColor.md
+++ b/src/bdscript/webhookColor.md
@@ -40,5 +40,5 @@ How [`$webhookCreate[]`](./webhookCreate.md), [`$webhookDescription[]`](./webhoo
 ```
 
 ```admonish info title="Read more"
-For more information, read the the [Webhooks Guide](../guides/general/webhooks.md).
+For more information, read the [Webhooks Guide](../guides/general/webhooks.md).
 ```

--- a/src/bdscript/webhookContent.md
+++ b/src/bdscript/webhookContent.md
@@ -37,5 +37,5 @@ How [`$webhookCreate[]`](./webhookCreate.md), [`$channelID`](./channelID.md) and
 ```
 
 ```admonish info title="Read more"
-For more information, read the the [Webhooks Guide](../guides/general/webhooks.md).
+For more information, read the [Webhooks Guide](../guides/general/webhooks.md).
 ```

--- a/src/bdscript/webhookCreate.md
+++ b/src/bdscript/webhookCreate.md
@@ -72,5 +72,5 @@ Created and saved!
 ~~~
 
 ```admonish info title="Read more"
-For more information, read the the [Webhooks Guide](../guides/general/webhooks.md).
+For more information, read the [Webhooks Guide](../guides/general/webhooks.md).
 ```

--- a/src/bdscript/webhookDelete.md
+++ b/src/bdscript/webhookDelete.md
@@ -37,5 +37,5 @@ How [`$webhookCreate[]`](./webhookCreate.md), [`$channelID`](./channelID.md) and
 ```
 
 ```admonish info title="Read more"
-For more information, read the the [Webhooks Guide](../guides/general/webhooks.md).
+For more information, read the [Webhooks Guide](../guides/general/webhooks.md).
 ```

--- a/src/bdscript/webhookDescription.md
+++ b/src/bdscript/webhookDescription.md
@@ -38,5 +38,5 @@ How [`$webhookCreate[]`](./webhookCreate.md), [`$channelID`](./channelID.md) and
 ```
 
 ```admonish info title="Read more"
-For more information, read the the [Webhooks Guide](../guides/general/webhooks.md).
+For more information, read the [Webhooks Guide](../guides/general/webhooks.md).
 ```

--- a/src/bdscript/webhookFooter.md
+++ b/src/bdscript/webhookFooter.md
@@ -38,5 +38,5 @@ How [`$webhookCreate[]`](./webhookCreate.md), [`$channelID`](./channelID.md) and
 ```
 
 ```admonish info title="Read more"
-For more information, read the the [Webhooks Guide](../guides/general/webhooks.md).
+For more information, read the [Webhooks Guide](../guides/general/webhooks.md).
 ```

--- a/src/bdscript/webhookSend.md
+++ b/src/bdscript/webhookSend.md
@@ -54,5 +54,5 @@ How [`$webhookCreate[]`](./webhookCreate.md), [`$channelID`](./channelID.md) and
 ```
 
 ```admonish info title="Read more"
-For more information, read the the [Webhooks Guide](../guides/general/webhooks.md).
+For more information, read the [Webhooks Guide](../guides/general/webhooks.md).
 ```

--- a/src/bdscript/webhookTitle.md
+++ b/src/bdscript/webhookTitle.md
@@ -38,5 +38,5 @@ How [`$webhookCreate[]`](./webhookCreate.md), [`$channelID`](./channelID.md) and
 ```
 
 ```admonish info title="Read more"
-For more information, read the the [Webhooks Guide](../guides/general/webhooks.md).
+For more information, read the [Webhooks Guide](../guides/general/webhooks.md).
 ```

--- a/src/bdscript/webhookUsername.md
+++ b/src/bdscript/webhookUsername.md
@@ -38,5 +38,5 @@ How [`$webhookCreate[]`](./webhookCreate.md), [`$channelID`](./channelID.md) and
 ```
 
 ```admonish info title="Read more"
-For more information, read the the [Webhooks Guide](../guides/general/webhooks.md).
+For more information, read the [Webhooks Guide](../guides/general/webhooks.md).
 ```

--- a/src/callbacks/awaitedCommand.md
+++ b/src/callbacks/awaitedCommand.md
@@ -5,7 +5,7 @@
 
 _Triggered when an awaited command gets initiated._
 
-`$awaitedCommand[]` is a callback, which means it's used in the command trigger (not the code). The command is ran when an awaited command gets initiated.
+`$awaitedCommand[]` is a callback, which means it's used in the command trigger (not the code). The command is run when an awaited command gets initiated.
 
 ## Syntax
 ```

--- a/src/callbacks/awaitedCommandError.md
+++ b/src/callbacks/awaitedCommandError.md
@@ -5,7 +5,7 @@
 
 _Triggered when an awaited command doesn't match with provided filter._
 
-`$awaitedCommandError[]` is a callback, which means it's used in the command trigger (not the code). The command is ran when an awaited command doesn't match with provided filter.
+`$awaitedCommandError[]` is a callback, which means it's used in the command trigger (not the code). The command is run when an awaited command doesn't match with provided filter.
 
 ## Syntax
 ```

--- a/src/callbacks/onBanAdd.md
+++ b/src/callbacks/onBanAdd.md
@@ -5,7 +5,7 @@
 
 *Triggered when a user gets banned from the server.*
 
-`$onBanAdd[Channel ID]` is a callback, which means it's used in the command trigger *(not the code)*. The command is ran when a user is banned from the server. 
+`$onBanAdd[Channel ID]` is a callback, which means it's used in the command trigger *(not the code)*. The command is run when a user is banned from the server. 
 
 ## Syntax
 ```

--- a/src/callbacks/onBanRemove.md
+++ b/src/callbacks/onBanRemove.md
@@ -5,7 +5,7 @@
 
 *Triggered when a user gets unbanned from the server.*
 
-`$onBanRemove[Channel ID]` is a callback, which means it's used in the command trigger *(not the code)*. The command is ran when a user is unbanned from the server. 
+`$onBanRemove[Channel ID]` is a callback, which means it's used in the command trigger *(not the code)*. The command is run when a user is unbanned from the server. 
 
 ## Syntax
 ```

--- a/src/callbacks/onJoined.md
+++ b/src/callbacks/onJoined.md
@@ -5,7 +5,7 @@
 
 *Triggered when a user joins the server.*
 
-`$onJoined[Channel ID]` is a callback, which means it's used in the command trigger *(not the code)*. The command is ran when a user joins the server.
+`$onJoined[Channel ID]` is a callback, which means it's used in the command trigger *(not the code)*. The command is run when a user joins the server.
 
 > You can only have **1** single `$onJoined[]` per bot.
 

--- a/src/callbacks/onLeave.md
+++ b/src/callbacks/onLeave.md
@@ -5,7 +5,7 @@
 
 *Triggered when a user leaves the server.*
 
-`$onLeave[Channel ID]` is a callback, which means it's used in the command trigger *(not the code)*. The command is ran when a user leaves the server.
+`$onLeave[Channel ID]` is a callback, which means it's used in the command trigger *(not the code)*. The command is run when a user leaves the server.
 
 > You can only have **1** single `$onLeave[]` per bot.
 

--- a/src/callbacks/onMessageDelete.md
+++ b/src/callbacks/onMessageDelete.md
@@ -5,7 +5,7 @@
 
 *Triggered when a user deletes a message.*
 
-`$onMessageDelete[Channel ID]` is a callback, which means it's used in the command trigger *(not the code)*. The command is ran when a user deletes a message.
+`$onMessageDelete[Channel ID]` is a callback, which means it's used in the command trigger *(not the code)*. The command is run when a user deletes a message.
 
 ## Syntax 
 ```

--- a/src/premium/awaitReactions.md
+++ b/src/premium/awaitReactions.md
@@ -49,5 +49,5 @@ How [`$addReactions[]`](../bdscript/addReactions.md) works?
 ```
 
 ```admonish info title="Read more"
-For more information, read the the [Awaited Reactions Guide](../premium/awaitedReactions.md).
+For more information, read the [Awaited Reactions Guide](../premium/awaitedReactions.md).
 ```

--- a/src/premium/customImage.md
+++ b/src/premium/customImage.md
@@ -35,5 +35,5 @@ $customImage[NiceImage]
 ```
 
 ```admonish info title="Read more"
-For more information, read the the [Custom Images Guide](../premium/customImages.md).
+For more information, read the [Custom Images Guide](../premium/customImages.md).
 ```

--- a/src/premium/reaction.md
+++ b/src/premium/reaction.md
@@ -49,5 +49,5 @@ $sendMessage[$username clicked on the reaction]
 ```
 
 ```admonish info title="Read more"
-For more information, read the the [Awaited Reactions Guide](../premium/awaitedReactions.md).
+For more information, read the [Awaited Reactions Guide](../premium/awaitedReactions.md).
 ```

--- a/src/premium/usedEmoji.md
+++ b/src/premium/usedEmoji.md
@@ -56,5 +56,5 @@ How [`$sendMessage[]`](../bdscript/sendMessage.md) works?
 ```
 
 ```admonish info title="Read more"
-For more information, read the the  [Awaited Reactions Guide](./awaitedReactions.md).
+For more information, read the [Awaited Reactions Guide](./awaitedReactions.md).
 ```


### PR DESCRIPTION
- Fix 31 instances of doubled "the the" across bdscript/, premium/, callbacks/
- Fix 8 instances of "ran when" → "run when" in callbacks (incorrect passive voice)
- Fix 4 typos in CONTRIBUTING.md: "consise", "attrubute", "Line-Truough", "filed"